### PR TITLE
added missing airflow dag dependencies in the airflowDb.Dockerfile

### DIFF
--- a/README_db.md
+++ b/README_db.md
@@ -22,7 +22,7 @@ In the root of this project add the following directories:
 ### Start the docker compose
 
 ```
-DOCKER_BUILDKIT=1 docker-compose up
+DOCKER_BUILDKIT=1 docker-compose up -d --force-recreate
 ```
 
 It will start the Postgres DB service as well as a container that will read data from

--- a/airflow/dags/1_training_pipeline_dag.py
+++ b/airflow/dags/1_training_pipeline_dag.py
@@ -10,9 +10,14 @@ from airflow.utils.dates import days_ago
 from airflow.utils.timezone import datetime
 
 import sys
+
 # the path to our source code directories
-sys.path.append('/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/src/data')
-sys.path.append('/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/src/models')
+sys.path.append(
+    "/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/src/data"
+)
+sys.path.append(
+    "/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/src/models"
+)
 
 cwd = os.getcwd()
 print(cwd)
@@ -23,7 +28,7 @@ from train_model import Train_Model
 
 from make_dataset_from_db import process_data
 
-from evaluate import evaluate
+from model_api.evaluate import evaluate
 
 # from cd4ml.data_processing import ingest_data
 # from cd4ml.data_processing import split_train_test
@@ -41,68 +46,63 @@ _model_name = "accidents_model"
 _mlflow_experiment_name = "accidents_experiment"
 
 
-
-
 default_args = {
-    'owner': 'ssime',
-    'depends_on_past': False,
-    'start_date': days_ago(0),
-    'retries': 1,
-    'retry_delay': timedelta(seconds=5),
-    'tags': ['accidents', 'train_model'],
+    "owner": "ssime",
+    "depends_on_past": False,
+    "start_date": days_ago(0),
+    "retries": 1,
+    "retry_delay": timedelta(seconds=5),
+    "tags": ["accidents", "train_model"],
 }
 
 dag = DAG(
-    'train_pipeline',
+    "train_pipeline",
     default_args=default_args,
-    description='Training  Pipeline',
+    tags=["road_accidents", "data_ingestion"],
+    description="Training  Pipeline",
     schedule_interval="0 */1 * * * ",
     catchup=False,
 )
 
 with dag:
-    
-    # the new data are read to db by Evan 
+
+    # the new data are read to db by Evan
     # So in the database we have updated the 4 files
-    # In any case, the training of the model runs by default every evening as 22:00 
+    # In any case, the training of the model runs by default every evening as 22:00
     # Regardless of new data have actually been ingested
-    # so the following steps need to be done 
+    # so the following steps need to be done
 
     # 1. ingest new data --> Evan to db
     # 2. preprocess data --> Josef, incl. split for train and test
-    # 3. train model --> train_model.py -> Josef 
-    # 4. validate model --> validate_model.py -> Josef using MLFlow 
+    # 3. train model --> train_model.py -> Josef
+    # 4. validate model --> validate_model.py -> Josef using MLFlow
     # 5. push model --> push_model.py -> Josef using MLFlow
-    
-    
-    # # 1. ingest new data
-    
 
-    # 2. preprocess data 
-    # the preprocessing relies on the script make_dataset_from_db.py 
+    # # 1. ingest new data
+
+    # 2. preprocess data
+    # the preprocessing relies on the script make_dataset_from_db.py
     # this file prepares features, cleans data and writes the train and test data
     # to Volume/data/preprocessed
 
     data_transformation = PythonOperator(
-        task_id='data_transformation',
+        task_id="data_transformation",
         python_callable=process_data,
-        op_kwargs={'output_folderpath': 'Volumes/data/preprocessed'}
+        op_kwargs={"output_folderpath": "Volumes/data/preprocessed"},
     )
 
-    # 3. Train model 
-    
+    # 3. Train model
+
     model_training = PythonOperator(
-        task_id='model_training',
-        python_callable = Train_Model,
-
+        task_id="model_training",
+        python_callable=Train_Model,
     )
-    
+
     model_metrics = PythonOperator(
-        task_id='model_metrics',
-        python_callable = evaluate,
-
+        task_id="model_metrics",
+        python_callable=evaluate,
     )
-    # 4. Validate model 
+    # 4. Validate model
     # model_validation = BranchPythonOperator(
     #     task_id='model_validation',
     #     python_callable=validate_model,
@@ -118,7 +118,7 @@ with dag:
     #     trigger_rule="all_done",
     # )
 
-    # 5. push model 
+    # 5. push model
     # push_to_production = PythonOperator(
     #     task_id='push_new_model',
     #     python_callable=push_model,
@@ -127,4 +127,4 @@ with dag:
     #     },
     # )
 
-    data_transformation >> model_training >> model_metrics  
+    data_transformation >> model_training >> model_metrics

--- a/airflow/dags/train_model.py
+++ b/airflow/dags/train_model.py
@@ -1,27 +1,27 @@
-
 import pandas as pd
 from sklearn import ensemble
 import joblib
 import numpy as np
 import os
-from src.data.check_structure import mv_existing_file_archive
+from model_api.feature_extraction.check_structure import mv_existing_file_archive
 
 
-model_base = '/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/airflow/Volumes/models'
-data_base = '/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/airflow/Volumes/data'
+model_base = "/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/airflow/Volumes/models"
+data_base = "/Users/drjosefhartmann/Development/Accidents/may24_bmlops_accidents/airflow/Volumes/data"
+
 
 def Train_Model():
     print(joblib.__version__, os.getcwd())
-    #execute from may24_BMLOPS_ACCIDENTS/src/models folder!
+    # execute from may24_BMLOPS_ACCIDENTS/src/models folder!
     # X_train = pd.read_csv("../../Volumes/data/preprocessed/X_train.csv")
     # X_test = pd.read_csv("../../Volumes/data/preprocessed/X_test.csv")
     # y_train = pd.read_csv("../../Volumes/data/preprocessed/y_train.csv")
     # y_test = pd.read_csv("../../Volumes/data/preprocessed/y_test.csv")
-    #execute from may24_BMLOPS_ACCIDENTS folder!
-    X_train = pd.read_csv(data_base + '/preprocessed/X_train.csv')
-    X_test = pd.read_csv(data_base + '/preprocessed/X_test.csv')
-    y_train = pd.read_csv(data_base + '/preprocessed/y_train.csv')
-    y_test = pd.read_csv(data_base + '/preprocessed/y_test.csv')
+    # execute from may24_BMLOPS_ACCIDENTS folder!
+    X_train = pd.read_csv(data_base + "/preprocessed/X_train.csv")
+    X_test = pd.read_csv(data_base + "/preprocessed/X_test.csv")
+    y_train = pd.read_csv(data_base + "/preprocessed/y_train.csv")
+    y_test = pd.read_csv(data_base + "/preprocessed/y_test.csv")
     y_train = np.ravel(y_train)
     y_test = np.ravel(y_test)
 
@@ -31,12 +31,11 @@ def Train_Model():
     rf_classifier.fit(X_train, y_train)
 
     # --Save the trained model to a file
-    #execute from may24_BMLOPS_ACCIDENTS folder!
-    
-    model_filename =  model_base + "/trained_model.joblib"
-    #execute from may24_BMLOPS_ACCIDENTS/src/models folder!
-    # model_filename = "../../Volumes/models/trained_model.joblib"
+    # execute from may24_BMLOPS_ACCIDENTS folder!
 
+    model_filename = model_base + "/trained_model.joblib"
+    # execute from may24_BMLOPS_ACCIDENTS/src/models folder!
+    # model_filename = "../../Volumes/models/trained_model.joblib"
 
     mv_existing_file_archive(model_base)
 
@@ -46,6 +45,7 @@ def Train_Model():
     loaded_model = joblib.load(model_filename)
 
     print("Model loaded successfully.")
+
 
 # if __name__ == '__main__':
 #     Train_Model()

--- a/airflowDb.Dockerfile
+++ b/airflowDb.Dockerfile
@@ -3,8 +3,9 @@ FROM apache/airflow:2.9.2
 WORKDIR /app
 
 #copy in the needed requirements and files
-COPY --chmod=777 python-packages/road_accidents_database_ingestion .
+COPY --chmod=777 python-packages/road_accidents_database_ingestion ./road_accidents_database_ingestion
+COPY --chmod=777 python-packages/model_api ./model_api
 
 # Note: Run this first `sudo chmod -R 777 python-packages/road_accidents_database_ingestion` otherwise the `python -m pip install -e .` will fail.
 #   or run `DOCKER_BUILDKIT=1 docker-compose up`
-RUN python -m ensurepip --upgrade && python -m pip install --upgrade pip && python -m pip install -e .
+RUN python -m ensurepip --upgrade && python -m pip install --upgrade pip && python -m pip install -e road_accidents_database_ingestion && python -m pip install -e model_api


### PR DESCRIPTION
This PR adds the missing Python libraries required by @DocJosef 's Airflow DAGs.

More specifically, the Airflow base Docker image (`airflowDb.Dockerfile`) now uses the following Python packages:

- `road_accidents_database_ingestion`
- `model_api`: For training and evaluating new ML models and also preprocessing data for the ML model.

@DocJosef I have updated 2 of your Python modules found in the `airflow/dags` folder to demonstrate how to use the installed python packages in the docker image. However please keep in mind that the python modules in the `airflow/dags` are not up to date. Your latest versions of these modules are in the `UserInterface` branch. However, now the Airflow UI can show your DAG: 
![dag](https://github.com/DataScientest-Studio/may24_bmlops_accidents/assets/4984702/17bb02aa-1ece-4055-95a2-603624c03b50)

My suggestion for your local development, so you have autocomplete functionality in your vscode:

- `python3.12 -m venv .venv`
- `source .venv/bin/activate`
- `python -m pip install -e python-packages/model_api`
- `python -m pip install -e python-packages/road_accidents_database_ingestion`


Then run the docker-compose with: 
`DOCKER_BUILDKIT=1 docker-compose up -d --force-recreate`
 