### PR TITLE
Set Airflow Variable when new data added to the DB

### DIFF
--- a/.env
+++ b/.env
@@ -8,12 +8,13 @@ MODEL_FILENAME="trained_model.joblib"
 MODEL_API_PORTS="8001:8000"
 
 # Road Accidents DB (Postgresql)
-# POSTGRES_USER=postgres
-# POSTGRES_PASSWORD=changeme
 ROAD_ACCIDENTS_POSTGRES_DB=RoadAccidents
 ROAD_ACCIDENTS_POSTGRES_PORT=5432
 ROAD_ACCIDENTS_POSTGRES_HOST=postgres_road_accidents
-ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR=/data/raw # Raw Road Accidents CSV files upload path in Docker
+# Raw Road Accidents CSV files upload path in Docker
+ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR=/data/raw
+# The name of the Airflow variable used between DAGs to indicate the time new Road Accidents data added to the db.
+AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME="new_road_accident_data_in_db_timestamp"
 
 # Road Accidents DB PgAdmin
 PGADMIN_DEFAULT_EMAIL=pgadmin4@pgadmin.org

--- a/airflow/dags/read_variable_dag.py
+++ b/airflow/dags/read_variable_dag.py
@@ -1,0 +1,36 @@
+import os
+
+from airflow import DAG
+from airflow.utils.dates import days_ago
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable
+
+import datetime
+
+AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME = os.getenv("AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME")
+
+def read_and_print_airflow_variable():
+    new_data_in_db_timestamp = Variable.get(AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME, None)
+    print('Hello from Airflow again')
+    if new_data_in_db_timestamp is not None:
+        print(f"New data added on '{new_data_in_db_timestamp}'.")
+    else:
+        print(f"The env variable '{AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME}' has not been set yet.")
+
+with DAG(
+    dag_id='read_variable_dag',
+    description='A DAG to read a variable, used for development only. Feel free to remove.',
+    tags=["road_accidents", "data_ingestion"],
+    schedule_interval=None,
+    default_args={
+        'owner': 'airflow',
+        'start_date': days_ago(2),
+    }
+) as my_dag:
+
+    my_read_var_task = PythonOperator(
+        task_id='read_airflow_var',
+        python_callable=read_and_print_airflow_variable,
+    )
+
+my_read_var_task

--- a/airflow/dags/set_variable_dag.py
+++ b/airflow/dags/set_variable_dag.py
@@ -1,0 +1,47 @@
+import os
+
+from airflow import DAG
+from airflow.utils.dates import days_ago
+from airflow.operators.python import PythonOperator
+from airflow.models import Variable
+
+import datetime
+
+
+# Definition of the function to be executed
+def print_date_and_hello():
+    print(datetime.datetime.now())
+    print("Hello from Airflow")
+
+
+def print_date_and_hello_again():
+    airflow_var_name = os.getenv("AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME")
+    my_variable_value = Variable.get(airflow_var_name, None)
+    print(f"current_value: {my_variable_value}")
+    Variable.set(airflow_var_name, datetime.datetime.now().isoformat())
+    my_updated_variable_value = Variable.get(airflow_var_name, 0)
+    print(my_updated_variable_value)
+
+
+with DAG(
+    dag_id="my_set_variable_dag",
+    description="A DAG to set a variable",
+    tags=["road_accidents", "data_ingestion"],
+    schedule_interval=None,
+    default_args={
+        "owner": "airflow",
+        "start_date": days_ago(2),
+    },
+) as my_dag:
+
+    my_task = PythonOperator(
+        task_id="my_very_first_task",
+        python_callable=print_date_and_hello,
+    )
+
+    my_task2 = PythonOperator(
+        task_id="my_second_task",
+        python_callable=print_date_and_hello_again,
+    )
+
+my_task >> my_task2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ x-airflow-common: &airflow-common
     ROAD_ACCIDENTS_POSTGRES_PORT: ${ROAD_ACCIDENTS_POSTGRES_PORT}
     ROAD_ACCIDENTS_POSTGRES_DB: ${ROAD_ACCIDENTS_POSTGRES_DB}
     ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR: ${ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR}
+    AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME: ${AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME}
     _AIRFLOW_WWW_USER_USERNAME: ${ADMIN_USERNAME}
     _AIRFLOW_WWW_USER_PASSWORD: ${ADMIN_PASSWORD}
 
@@ -76,10 +77,19 @@ services:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
       PGADMIN_DEFAULT_PASSWORD: ${ADMIN_PASSWORD}
       PGADMIN_CONFIG_SERVER_MODE: 'False'
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+      PGPASSFILE: /pgpass
     volumes:
       - ./Volumes/db_admin:/var/lib/pgadmin
     depends_on:
       - postgres_road_accidents
+    entrypoint: /bin/sh -c "chown 5050:5050 /pgpass;chmod 0600 /pgpass; /entrypoint.sh;"
+    user: root
+    configs:
+      - source: pgadmin_servers_conf_json
+        target: /pgadmin4/servers.json
+      - source: pgadmin_pgpass_conf_file
+        target: /pgpass
 
   model_api:
     image: model_api:latest
@@ -292,3 +302,25 @@ services:
 
 volumes:
   postgres-db-volume:
+
+configs:
+  pgadmin_pgpass_conf_file:
+    content: ${ROAD_ACCIDENTS_POSTGRES_HOST}:${ROAD_ACCIDENTS_POSTGRES_PORT}:${ROAD_ACCIDENTS_POSTGRES_DB}:${ADMIN_USERNAME}:${ADMIN_PASSWORD}
+  pgadmin_servers_conf_json:
+    content: |
+      {"Servers": {"1": {
+            "Name": "RoadAccidents",
+            "Group": "Servers",
+            "Host": "${ROAD_ACCIDENTS_POSTGRES_HOST}",
+            "Port": ${ROAD_ACCIDENTS_POSTGRES_PORT},
+            "MaintenanceDB": "${ROAD_ACCIDENTS_POSTGRES_DB}",
+            "Username": "${ADMIN_USERNAME}",
+            "UseSSHTunnel": 0,
+            "TunnelPort": "22",
+            "TunnelAuthentication": 0,
+            "KerberosAuthentication": false,
+            "PassFile": "/pgpass",
+            "ConnectionParameters": {
+                "sslmode": "prefer",
+                "connect_timeout": 10  
+      }}}}

--- a/python-packages/road_accidents_database_ingestion/README.md
+++ b/python-packages/road_accidents_database_ingestion/README.md
@@ -55,5 +55,6 @@ Make sure to run this command first `sudo chmod -R 777 python-packages/road_acci
 # TODO
 
 - [sos] ignore empty dirs
+- Consider using the `md5` as the primary key for the `RawRoadAccidentsCsvFile` table.
 - Remove `tqdm` from stdout because it floods the airflow logs!
 - Finish this documentation (project structure)

--- a/python-packages/road_accidents_database_ingestion/src/road_accidents_database_ingestion/db_tasks.py
+++ b/python-packages/road_accidents_database_ingestion/src/road_accidents_database_ingestion/db_tasks.py
@@ -58,7 +58,10 @@ def _add_data_to_table(
     db_session: Session, df: pd.DataFrame, table_model: SQLModel):
     print(f"Adding data to the '{table_model.__tablename__}' table.")
 
-    for _, row in tqdm.tqdm(df.iterrows(), total=len(df)):
+    for _, row in tqdm.tqdm(df.iterrows(), 
+                            total=len(df), 
+                            desc=f"Updating table: '{table_model.__tablename__}'",
+                            mininterval=1.0):
         carac = table_model(**row)
         db_session.add(carac)
     db_session.commit()


### PR DESCRIPTION
This PR adds a new task to the `ingest_road_accident_csv_to_db.py` DAG that sets an Airflow variable every time new road accident data are added to the DB. The name of the Airflow variable is stored is the `.env` file as `AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME`.

A minor change is that I created a default configuration for the `PgAdmin` container using information from the `.env` file. 

