### PR TITLE
Fixed green light ui assets path

### DIFF
--- a/.github/workflows/build-and-push-docker-images.yml
+++ b/.github/workflows/build-and-push-docker-images.yml
@@ -1,0 +1,19 @@
+name: PR merged to master
+
+on:
+    pull_request:
+        types:
+        - closed
+
+permissions:
+  contents: read
+
+jobs:
+    if_merged:
+      if: github.event.pull_request.merged == true
+      runs-on: ubuntu-latest
+      steps:
+      - name: BuildAndPushDockerImages
+        run: |
+          echo The PR was merged
+  

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -109,9 +109,8 @@ jobs:
           python -m pip install -e python-packages/green_light_ui
       
       - name: Test green_light_ui package
-        uses: streamlit/streamlit-app-action@v0.0.3
-        with:
-          app-path: python-packages/green_light_ui/src/app.py
+        run: |
+          pytest python-packages/green_light_ui/tests
   
       - name: Login to the Docker Hub
         uses: docker/login-action@v1

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -106,11 +106,12 @@ jobs:
         
       - name: Install green_light_ui package 
         run: |
-          python -m pip install -e python-packages/model_api
+          python -m pip install -e python-packages/green_light_ui
       
       - name: Test green_light_ui package
-        run: |
-          pytest python-packages/model_api/tests
+        uses: streamlit/streamlit-app-action@v0.0.3
+        with:
+          app-path: python-packages/green_light_ui/src/app.py
   
       - name: Login to the Docker Hub
         uses: docker/login-action@v1

--- a/python-packages/green_light_ui/README.md
+++ b/python-packages/green_light_ui/README.md
@@ -32,13 +32,22 @@ The Python scripts are configured through the following enviroment variables:
 
 - TODO: None yet but probably the admin username & password in order to call the Model API and get the authorization token.
 
+## Running the UI Locally (no docker)
+
+Assumming you are in the root directory of the `green_light_ui` Python project, then run:
+
+```
+streamlit run src/green_light_ui/app.py --server.port=8501 --server.address=localhost
+```
+
+Then access the UI: [localhost](http://localhost:8501/)
 
 ## Building the Docker Image
 
-Build the docker image:
+Assumming you are in the root directory of the `green_light_ui` Python project, then build the docker image by:
 
 ```
-DOCKER_BUILDKIT=1 docker image build --no-cache . -t accidents_ui:latest
+DOCKER_BUILDKIT=1 docker image build --no-cache . -t roadaccidentsmlops24/accidents_ui:latest
 ```
 
 >> If `DOCKER_BUILDKIT=1` doesn't work for you then before building the docker image run:
@@ -50,17 +59,6 @@ sudo chmod -R 777 python-packages/green_light_ui
 ```
 docker container run --name accidents_ui -p 8501:8501 roadaccidentsmlops24/accidents_ui:latest
 ```
-
-## Running the UI Locally (no docker)
-
-
-```
-streamlit run src/green_light_ui/app.py --server.port=8501 --server.address=localhost
-```
-
-Then access the UI: [localhost](http://localhost:8501/)
-
-
 
 # Further reading
 

--- a/python-packages/green_light_ui/src/green_light_ui/app.py
+++ b/python-packages/green_light_ui/src/green_light_ui/app.py
@@ -6,7 +6,7 @@ from PIL import Image
 import config
 
 
-from tabs import intro, service_platform, api, updates, training, evaluation, ci_cd, monitoring
+from tabs import intro, user_interface, service_platform, api, updates, training, evaluation, ci_cd, monitoring
 
 
 # File locatements in Docker
@@ -31,7 +31,7 @@ TABS = OrderedDict(
         (intro.sidebar_name, intro),
         (service_platform.sidebar_name, service_platform),
         (api.sidebar_name, api),
-        # (user_interface.sidebar_name, user_interface),
+        (user_interface.sidebar_name, user_interface),
         (updates.sidebar_name, updates),
         (training.sidebar_name, training),
         (evaluation.sidebar_name, evaluation),

--- a/python-packages/green_light_ui/src/green_light_ui/app.py
+++ b/python-packages/green_light_ui/src/green_light_ui/app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from collections import OrderedDict
 
 import streamlit as st
@@ -5,11 +6,11 @@ from PIL import Image
 import config
 
 
-from tabs import user_interface, intro, service_platform, api, updates, training, evaluation, ci_cd, monitoring
+from tabs import intro, service_platform, api, updates, training, evaluation, ci_cd, monitoring
 
 
 # File locatements in Docker
-streamlit_base = '/app/src/green_light_ui'
+app_script_base = Path(__file__).parent
 
 
 st.set_page_config(
@@ -17,7 +18,7 @@ st.set_page_config(
     # page_icon="assets/model.png",
 )
 
-with open(streamlit_base + "/style.css", "r") as f:
+with open(app_script_base / "style.css", "r") as f:
     style = f.read()
 
 st.markdown(f"<style>{style}</style>", unsafe_allow_html=True)
@@ -30,7 +31,7 @@ TABS = OrderedDict(
         (intro.sidebar_name, intro),
         (service_platform.sidebar_name, service_platform),
         (api.sidebar_name, api),
-        (user_interface.sidebar_name, user_interface),
+        # (user_interface.sidebar_name, user_interface),
         (updates.sidebar_name, updates),
         (training.sidebar_name, training),
         (evaluation.sidebar_name, evaluation),
@@ -42,7 +43,7 @@ TABS = OrderedDict(
 
 def run():
 
-    image = Image.open(streamlit_base+"/assets/GreenLights.png")
+    image = Image.open(app_script_base / "assets/GreenLights.png")
     st.sidebar.image(
         image,
         width=100,

--- a/python-packages/green_light_ui/src/green_light_ui/tabs/service_platform.py
+++ b/python-packages/green_light_ui/src/green_light_ui/tabs/service_platform.py
@@ -1,11 +1,13 @@
+from pathlib import Path
+
 import streamlit as st
 import pandas as pd
 import numpy as np
 
 
 
-# File locations in Docker
-streamlit_base = '/app/src/green_light_ui'
+# Root dir of the green light ui project
+green_light_ui_base = Path(__file__).parent.parent
 
 # Page settings
 
@@ -19,4 +21,4 @@ def run():
     st.title(title)
 
     st.markdown("## Description of the GreenLightServices Platform ")
-    st.image(streamlit_base + "/assets/ServicePlatform.png")
+    st.image(str(green_light_ui_base / "assets" / "ServicePlatform.png"))

--- a/python-packages/green_light_ui/src/green_light_ui/tabs/user_interface.py
+++ b/python-packages/green_light_ui/src/green_light_ui/tabs/user_interface.py
@@ -6,29 +6,16 @@ import time
 from pydantic import BaseModel
 import requests
 
-
-# File locations in Docker
-data_base = '/data'
-
-
 # URLs  
 url_prediction = "http://model_api_from_compose:8000/predict"
 
-
 # Page settings 
-
 title = "GreenLightServices - Make a Prediction"
 sidebar_name = "User Interface"
-
-
-
-
 
 ## Definitions
 
 # Stuff for the UI-Layout to input the features
-
-X_train = pd.read_csv(data_base + '/preprocessed/X_train.csv')
 
 features = {
     "place": 10,
@@ -154,10 +141,6 @@ def input_feature(feature):
     this is required to build the three input columns with flexible number of rows
     depending on the number of core features 
     '''
-    # lookup values 
-    options = list(X_train[feature].unique())
-    options.sort()
-    idx = options.index(features[feature])
     
     st.write(f"**'{feature_en[feature]}'**, Default: {features[feature]}")
     value = st.number_input(feature_en[feature],label_visibility="collapsed", value = new_features[feature])
@@ -174,9 +157,6 @@ def run():
     # settings
     global new_features
     global features
-
-    
-    X_cols = X_train.columns.tolist()
     
     st.title(title)
 

--- a/python-packages/green_light_ui/tests/test_app.py
+++ b/python-packages/green_light_ui/tests/test_app.py
@@ -1,7 +1,10 @@
+from pathlib import Path
 from streamlit.testing.v1 import AppTest
 
 
 def test_the_streamlit_app_runs():
     """Tests that the streamlit app starts properly."""
-    at = AppTest.from_file("src/green_light_ui/app.py").run()
+    current_path = Path(__file__).parent
+    project_path = current_path.parent
+    at = AppTest.from_file(str(project_path / "src" / "green_light_ui" / "app.py")).run()
     assert True

--- a/python-packages/green_light_ui/tests/test_app.py
+++ b/python-packages/green_light_ui/tests/test_app.py
@@ -1,0 +1,7 @@
+from streamlit.testing.v1 import AppTest
+
+
+def test_the_streamlit_app_runs():
+    """Tests that the streamlit app starts properly."""
+    at = AppTest.from_file("src/green_light_ui/app.py").run()
+    assert True

--- a/python-packages/green_light_ui/tests/test_stub.py
+++ b/python-packages/green_light_ui/tests/test_stub.py
@@ -1,4 +1,0 @@
-import pytest
-
-def test_always_pass():
-    assert True


### PR DESCRIPTION
Fixed a path bug in the green light UI so it can start:
- The paths are now relative and independent of where you run the code from (locally, docker, local directory, etc)
- Added a unit test to make sure the streamlit app starts without errors.

Added a dummy github workflow yaml which should run when we merge a PR to master.
