### PR TITLE
fixed and tested an env variable issue with a db ingestion dag

### DIFF
--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ ROAD_ACCIDENTS_POSTGRES_PORT=5432
 ROAD_ACCIDENTS_POSTGRES_HOST=postgres_road_accidents
 # Raw Road Accidents CSV files upload path in Docker
 ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR=/data/raw
-ROAD_ACCIDENTS_DIRS=$ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR/raw
+ROAD_ACCIDENTS_DIRS=${ROAD_ACCIDENTS_RAW_CSV_FILES_ROOT_DIR}/raw
 # The name of the Airflow variable used between DAGs to indicate the time new Road Accidents data added to the db.
 AIRFLOW_NEW_DATA_IN_ROAD_ACCIDENTS_DB_VARNAME="new_road_accident_data_in_db_timestamp"
 

--- a/DEV-docker-compose-up.sh
+++ b/DEV-docker-compose-up.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+######################################################################################
+# This shell scripts starts the docker-compose application in Development mode       #
+#   Development mode means that instead of pulling our Docker images from the        #
+#   DockerHub (CI/CD pipeline), it builds the local Docker Images.                   #
+#                                                                                    #  
+# Execute this script from the root directory of the may24_bmlops_accidents project: #
+#   ./DEV-docker-compose-up.sh                                                       #
+######################################################################################
+
+echo "Remove all Docker Images not assigned to a Docker Container"
+docker image prune -a
+
+echo "Build the local 'airflowdb' Docker Image"
+cd python-packages
+DOCKER_BUILDKIT=1 docker image build --no-cache -f airflowdb.Dockerfile . -t roadaccidentsmlops24/airflowdb:latest
+
+echo "Build the local 'model_api' Docker Image"
+cd model_api
+DOCKER_BUILDKIT=1 docker image build --no-cache . -t roadaccidentsmlops24/model_api:latest
+
+echo "Build the local 'green_light_ui' Docker Image"
+cd ../green_light_ui
+DOCKER_BUILDKIT=1 docker image build --no-cache . -t roadaccidentsmlops24/accidents_ui:latest
+
+echo "Start the Docker Compose App."
+cd ../../
+DOCKER_BUILDKIT=1 docker-compose up -d

--- a/PROD-docker-compose-up.sh
+++ b/PROD-docker-compose-up.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+######################################################################################
+# This shell scripts starts the docker-compose application in Production mode        #
+#   Production mode means that the Docker images will be pulled from the DockerHub   #
+#   (added there from our CI/CD pipeline).                                           #
+#                                                                                    #  
+# Execute this script from the root directory of the may24_bmlops_accidents project: #
+#   ./PROD-docker-compose-up.sh                                                      #
+######################################################################################
+
+echo "Remove all Docker Images not assigned to a Docker Container"
+docker image prune -a
+
+echo "Start the Docker Compose App."
+cd ../../
+DOCKER_BUILDKIT=1 docker-compose up -d


### PR DESCRIPTION
This PR fixes an env variable configuration issue with the data ingestion DAG.

Also introduces 2 shell scripts to start our docker-compose app:

- `DEV-docker-compose-up.sh` first builds the doker images using the local dockerfiles and then runs docker compose up
- `PROD-docker-compose-up.sh` runs docker compose up which then will pull the docker images from the dockerhub (ci/cd)